### PR TITLE
Pin OpenScale version to 1.0.429 .

### DIFF
--- a/examples/AIopenScaleSageMakerMLengineExampleOutput.ipynb
+++ b/examples/AIopenScaleSageMakerMLengineExampleOutput.ipynb
@@ -87,7 +87,7 @@
     }
    ],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {

--- a/notebooks/AIopenScaleSageMakerMLengine.ipynb
+++ b/notebooks/AIopenScaleSageMakerMLengine.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale --no-cache | tail -n 1"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {


### PR DESCRIPTION
New notebook for version 2.x will follow after testing and updates
for new data set.
This is a workaround.